### PR TITLE
Warn server administrators when using a default provided pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /.gradle/
 /.idea/
 /build/
+api/build/
+spigot/build/
+velocity/build/

--- a/velocity/src/main/java/com/convallyria/forcepack/velocity/ForcePackVelocity.java
+++ b/velocity/src/main/java/com/convallyria/forcepack/velocity/ForcePackVelocity.java
@@ -138,6 +138,7 @@ public class ForcePackVelocity implements ForcePackAPI {
             AtomicInteger sizeInMB = new AtomicInteger();
 
             this.checkValidEnding(url);
+            this.checkForRehost(url, serverName);
 
             ResourcePackURLData data = this.tryGenerateHash(resourcePack, url, hash, sizeInMB);
             if (data != null) hash = data.getUrlHash();
@@ -204,6 +205,8 @@ public class ForcePackVelocity implements ForcePackAPI {
             final String url = unloadPack.getString("url");
             final String hash = unloadPack.getString("hash");
 
+            this.checkForRehost(url, "unload-pack");
+
             final VelocityResourcePack resourcePack = new VelocityResourcePack(this, EMPTY_SERVER_NAME, url, hash, 0);
             resourcePacks.add(resourcePack);
         }
@@ -216,6 +219,8 @@ public class ForcePackVelocity implements ForcePackAPI {
             if (enableGlobal) {
                 final String url = globalPack.getString("url");
                 final String hash = globalPack.getString("hash");
+
+                this.checkForRehost(url, "global-pack");
 
                 final VelocityResourcePack resourcePack = new VelocityResourcePack(this, GLOBAL_SERVER_NAME, url, hash, 0);
                 resourcePacks.add(resourcePack);
@@ -238,6 +243,24 @@ public class ForcePackVelocity implements ForcePackAPI {
             getLogger().error("Your URL has an invalid or unknown format. " +
                     "URLs must have no redirects and use the .zip extension. If you are using Dropbox, change ?dl=0 to ?dl=1.");
             getLogger().error("ForcePack will still load in the event this check is incorrect. Please make an issue or pull request if this is so.");
+        }
+    }
+
+    private void checkForRehost(String url, String section) {
+        List<String> warnForHost = Arrays.asList("convallyria.com");
+        boolean rehosted = true;
+        for (String host : warnForHost) {
+            if (url.contains(host)) {
+                rehosted = false;
+                break;
+            }
+        }
+
+        if (!rehosted) {
+            getLogger().warn(String.format("[%s] You are using a default resource pack provided by the plugin.", section) +
+                    "It's highly recommended you re-host this pack on a CDN such as https://mc-packs.net for faster load times. " +
+                    "Leaving this as default potentially sends a lot of requests to my personal web server, which isn't ideal!");
+            getLogger().warn("ForcePack will still load and function like normally.");
         }
     }
 

--- a/velocity/src/main/resources/config.toml
+++ b/velocity/src/main/resources/config.toml
@@ -52,9 +52,11 @@ try-to-stop-fake-accept-hacks = true
 debug = false
 
 [unload-pack]
-    # Whether to send an empty ResourcePack when joining a server without one configured, and the player has one applied
+    # Whether to send an empty resource pack when joining a server without one configured, and the player has one applied
     enable = true
     # The URL of the unload pack
+    # It's highly recommended you re-host this pack on a CDN such as mc-packs.net for faster load times.
+    # Leaving this as default potentially sends a lot of requests to my personal web server, which isn't ideal!
     url = "https://www.convallyria.com/files/BlankPack.zip"
     # The SHA-1 hash of the unload pack file
     hash = "118AFFFC54CDCD308702F81BA24E03223F15FE5F"


### PR DESCRIPTION
I can imagine the load on your web-server growing exponentially the more servers adopt your plugin.
This might get server admins to re-host the provided pack so that players connect to a less strained download server which also
has the benefit of faster downloads.