### PR TITLE
Sends title to players while pack is loading for slow clients

### DIFF
--- a/spigot/src/main/java/com/convallyria/forcepack/spigot/translation/Translations.java
+++ b/spigot/src/main/java/com/convallyria/forcepack/spigot/translation/Translations.java
@@ -13,6 +13,8 @@ import java.io.File;
 public enum Translations {
     DECLINED(TranslationKey.of("declined")),
     ACCEPTED(TranslationKey.of("accepted")),
+    DOWNLOAD_START_TITLE(TranslationKey.of("download_start_title")),
+    DOWNLOAD_START_SUBTITLE(TranslationKey.of("download_start_subtitle")),
     DOWNLOAD_FAILED(TranslationKey.of("download_failed")),
     PROMPT_TEXT(TranslationKey.of("prompt_text")),
     RELOADING(TranslationKey.of("reloading"));

--- a/spigot/src/main/resources/config.yml
+++ b/spigot/src/main/resources/config.yml
@@ -29,6 +29,10 @@ use-new-force-pack-screen: true
 # Still bypassable, but some are stupid and we are able to detect them.
 try-to-stop-fake-accept-hacks: true
 
+# Slow clients might take some time between accepting the pack and then successfully loading.
+# Option to send a title asking them to wait patiently
+send-loading-title: true
+
 Server:
   ResourcePack:
     # The ResourcePack URL. This must be a direct URL, ending with .zip. For Dropbox URLs, add ?dl=1 to the end.

--- a/spigot/src/main/resources/lang/en_gb.yml
+++ b/spigot/src/main/resources/lang/en_gb.yml
@@ -1,6 +1,8 @@
 # ForcePack uses Languagy. Language files will automatically update. Learn more here: https://fortitude.islandearth.net/en/languagy
 declined: "&cYou must accept the resource pack to play on our server. Don't know how? Check out &ehttps://samb440.gitlab.io/resourcepack.html."
 accepted: "&aThank you for accepting our resource pack! You can now play."
+download_start_title: "&6Downloading resource pack..."
+download_start_subtitle: "&6This may take a moment..."
 download_failed: "&cThe resource pack download failed. Please reconnect and try again."
 prompt_text: "&ePlease accept our resource pack to improve your server experience!" # Only on 1.18+ (1.17 does not have API)
 reloading: "&aRe-applying your resource pack due to an update!"


### PR DESCRIPTION
Slow clients might take some time between accepting the pack and then successfully loading... we bridge this waiting gab by sending a title asking them to wait patiently.