### PR TITLE
Remove instead of putting null.

### DIFF
--- a/spigot/src/main/java/com/convallyria/forcepack/spigot/listener/ResourcePackListener.java
+++ b/spigot/src/main/java/com/convallyria/forcepack/spigot/listener/ResourcePackListener.java
@@ -131,7 +131,7 @@ public class ResourcePackListener implements Listener {
         if (!canBypass && !geyser) {
             if (plugin.velocityMode) {
                 plugin.log("Velocity mode is enabled");
-                plugin.getWaiting().put(player.getUniqueId(), null);
+                plugin.getWaiting().remove(player.getUniqueId());
                 return;
             }
 


### PR DESCRIPTION
Causes a movement prevent issue.

SUCCESSFULLY_LOADED status will be send before PlayerJoinEvent so it won't be able to remove it in [here](https://github.com/SamB440/ForcePack/blob/master/spigot/src/main/java/com/convallyria/forcepack/spigot/listener/ResourcePackListener.java#L49)

putting null in to a map is still putting a key with null value so, ExemptionListener will still prevent our movements.

Debug:
```
[17:50:51 INFO]: [ForcePack] portlek's exemptions: geyser, false. permission, false.
[17:50:51 INFO]: [ForcePack] portlek sent status: SUCCESSFULLY_LOADED
[17:50:51 INFO]: [ForcePack] portlek's exemptions: geyser, false. permission, false.
[17:50:51 INFO]: [ForcePack] Velocity mode is enabled
[17:50:54 INFO]: [ForcePack] Cancelled movement for player 'portlek' due to resource pack not applied.
[17:50:54 INFO]: [ForcePack] Cancelled movement for player 'portlek' due to resource pack not applied.
[17:50:55 INFO]: [ForcePack] Cancelled movement for player 'portlek' due to resource pack not applied.
[17:50:55 INFO]: [ForcePack] Cancelled movement for player 'portlek' due to resource pack not applied.
```

Update:
Tested and it's working now.