### PR TITLE
Clear global packs on reloads

### DIFF
--- a/velocity/src/main/java/com/convallyria/forcepack/velocity/ForcePackVelocity.java
+++ b/velocity/src/main/java/com/convallyria/forcepack/velocity/ForcePackVelocity.java
@@ -199,7 +199,10 @@ public class ForcePackVelocity implements ForcePackAPI {
     }
 
     public void loadResourcePacks(@Nullable Player player) {
-        resourcePacks.clear(); // Clear for reloads
+        // Clear for reloads
+        resourcePacks.clear();
+        globalResourcePacks.clear();
+
         getWebServer().ifPresent(ForcePackWebServer::clearHostedPacks);
 
         this.checkUnload();


### PR DESCRIPTION
This fixes the issue with duplicated global packs on plugin reloads