### PR TITLE
Fix a NPE when a user don't exist for packetevents

### DIFF
--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
         exclude("com.convallyria.languagy.libs")
     }
     implementation("org.bstats:bstats-bukkit:3.0.2")
-    implementation("com.github.retrooper.packetevents:spigot:${properties["packetevents_version"]}")
+    implementation("com.github.retrooper:packetevents-spigot:${properties["packetevents_version"]}")
 }
 
 tasks {

--- a/spigot/src/main/java/com/convallyria/forcepack/spigot/util/ProtocolUtil.java
+++ b/spigot/src/main/java/com/convallyria/forcepack/spigot/util/ProtocolUtil.java
@@ -13,10 +13,19 @@ import org.bukkit.entity.Player;
 public class ProtocolUtil {
 
     public static int getProtocolVersion(Player player) {
-        final boolean viaversion = Bukkit.getPluginManager().isPluginEnabled("ViaVersion");
-        return viaversion
-                ? Via.getAPI().getPlayerVersion(player)
-                : PacketEvents.getAPI().getPlayerManager().getUser(player).getClientVersion().getProtocolVersion();
+        if(Bukkit.getPluginManager().isPluginEnabled("ViaVersion")) {
+            return Via.getAPI().getPlayerVersion(player);
+        }
+
+        final User user = PacketEvents.getAPI().getPlayerManager().getUser(player);
+
+        // PacketEvents will not create users for fake online players
+        // so we can safely assume that if the user is null, the player is fake
+        if(user == null) {
+            return -1;
+        }
+
+        return user.getClientVersion().getProtocolVersion();
     }
 
     private static boolean warnedBadPlugin;


### PR DESCRIPTION
I added a check if the user is null for packetevents to fix if the user don't exist for packetevents and instead return `-1`.

Also I changed the packetevents declaration since [they changed it](https://safe.manu.moe/6RwmqPTS.png) with 2.3.1 and ongoing.

_Generally speaking I would recommend to completely ignore users that don't exist in packetevents, since they always will be fake players. If you want I can create a pr that addresses this!_