### PR TITLE
Bump Kyori & Add fake-player metadata

### DIFF
--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -16,8 +16,8 @@ repositories {
 configurations {
     all {
         resolutionStrategy {
-            force("net.kyori:adventure-api:4.17.0")
-            force("net.kyori:adventure-bom:4.17.0")
+            force("net.kyori:adventure-api:4.19.0")
+            force("net.kyori:adventure-bom:4.19.0")
         }
     }
 }
@@ -40,7 +40,7 @@ dependencies {
     implementation("net.kyori:adventure-platform-bukkit:4.3.4") {
         exclude("net.kyori", "adventure-api") // not up-to-date - use minimessage version
     }
-    implementation("net.kyori:adventure-text-minimessage:4.17.0")
+    implementation("net.kyori:adventure-text-minimessage:4.19.0")
     implementation("com.convallyria.languagy:api:3.0.3-SNAPSHOT") {
         exclude("com.convallyria.languagy.libs")
     }

--- a/spigot/src/main/java/com/convallyria/forcepack/spigot/listener/ResourcePackListener.java
+++ b/spigot/src/main/java/com/convallyria/forcepack/spigot/listener/ResourcePackListener.java
@@ -201,7 +201,7 @@ public class ResourcePackListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        if (player.hasMetadata("NPC")) return;
+        if (player.hasMetadata("NPC") || player.hasMetadata("fake-player")) return;
 
         boolean geyser = plugin.getConfig().getBoolean("Server.geyser") && GeyserUtil.isBedrockPlayer(player.getUniqueId());
         boolean canBypass = player.hasPermission(Permissions.BYPASS) && getConfig().getBoolean("Server.bypass-permission");


### PR DESCRIPTION
Citizens reserves the "NPC" metadata, and other plugins' fake players can't reliably use this tag as it breaks some important functionality in them. Adding a separate "fake-player" check ensures that fake players are properly handled across different plugins. 

Also bumped kyori to 4.19.0 so it now include ARGBLike (after building with 4.17.0, it would show ARGBLike class not found).