### PR TITLE
Pack exempting

### DIFF
--- a/api/src/main/java/com/convallyria/forcepack/api/ForcePackAPI.java
+++ b/api/src/main/java/com/convallyria/forcepack/api/ForcePackAPI.java
@@ -4,6 +4,7 @@ import com.convallyria.forcepack.api.resourcepack.ResourcePack;
 import com.convallyria.forcepack.api.schedule.PlatformScheduler;
 
 import java.util.Set;
+import java.util.UUID;
 
 public interface ForcePackAPI {
 
@@ -20,4 +21,10 @@ public interface ForcePackAPI {
      * @return the scheduler for this server platform
      */
     PlatformScheduler<?> getScheduler();
+
+    /**
+     * @param uuid The UUID of the player to exempt the next resource pack send from.
+     * @return true if the player was successfully exempted, false if they were already on the exemption list.
+     */
+    boolean exemptNextResourcePackSend(UUID uuid);
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("io.github.goooler.shadow") version "8.1.8"
     id("java")
-    `maven-publish`
 }
 
 dependencies {
@@ -19,20 +18,6 @@ tasks {
 
     build {
         dependsOn(shadowJar)
-    }
-}
-
-publishing {
-    publications {
-        create<MavenPublication>("mavenJava") {
-            groupId = "com.convallyria.forcepack"
-            artifactId = "ForcePack"
-            version = "1.3.72"
-            artifact(file("C:/Users/Tom/IdeaProjects/ForcePack/build/libs/ForcePack-1.3.72.jar"))
-        }
-    }
-    repositories {
-        mavenLocal()
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("io.github.goooler.shadow") version "8.1.8"
     id("java")
+    `maven-publish`
 }
 
 dependencies {
@@ -18,6 +19,20 @@ tasks {
 
     build {
         dependsOn(shadowJar)
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            groupId = "com.convallyria.forcepack"
+            artifactId = "ForcePack"
+            version = "1.3.72"
+            artifact(file("C:/Users/Tom/IdeaProjects/ForcePack/build/libs/ForcePack-1.3.72.jar"))
+        }
+    }
+    repositories {
+        mavenLocal()
     }
 }
 

--- a/spigot/src/main/java/com/convallyria/forcepack/spigot/ForcePackSpigot.java
+++ b/spigot/src/main/java/com/convallyria/forcepack/spigot/ForcePackSpigot.java
@@ -69,6 +69,8 @@ public final class ForcePackSpigot extends JavaPlugin implements ForcePackAPI {
 
     private BukkitAudiences adventure;
 
+    public final Set<UUID> temporaryExemptedPlayers = new HashSet<>();
+
     @Override
     public Set<ResourcePack> getResourcePacks() {
         return resourcePacks.values().stream()
@@ -118,6 +120,11 @@ public final class ForcePackSpigot extends JavaPlugin implements ForcePackAPI {
     @Override
     public PlatformScheduler<?> getScheduler() {
         return scheduler;
+    }
+
+    @Override
+    public boolean exemptNextResourcePackSend(UUID uuid) {
+        return temporaryExemptedPlayers.add(uuid);
     }
 
     private final Map<UUID, ForcePackPlayer> waiting = new HashMap<>();

--- a/spigot/src/main/java/com/convallyria/forcepack/spigot/listener/ResourcePackListener.java
+++ b/spigot/src/main/java/com/convallyria/forcepack/spigot/listener/ResourcePackListener.java
@@ -53,7 +53,7 @@ public class ResourcePackListener implements Listener {
         }
 
         if (plugin.temporaryExemptedPlayers.remove(player.getUniqueId())) {
-            plugin.log("Ignoring player " + player.getName() + " as they do not have permissions or are a geyser player.");
+            plugin.log("Ignoring player " + player.getName() + " as they have a one-off exemption.");
             return;
         }
 

--- a/spigot/src/main/java/com/convallyria/forcepack/spigot/listener/ResourcePackListener.java
+++ b/spigot/src/main/java/com/convallyria/forcepack/spigot/listener/ResourcePackListener.java
@@ -52,6 +52,11 @@ public class ResourcePackListener implements Listener {
             return;
         }
 
+        if (plugin.temporaryExemptedPlayers.remove(player.getUniqueId())) {
+            plugin.log("Ignoring player " + player.getName() + " as they do not have permissions or are a geyser player.");
+            return;
+        }
+
         final ResourcePackStatus status = event.getStatus();
         plugin.log(player.getName() + " sent status: " + status);
 

--- a/spigot/src/main/java/com/convallyria/forcepack/spigot/listener/ResourcePackListener.java
+++ b/spigot/src/main/java/com/convallyria/forcepack/spigot/listener/ResourcePackListener.java
@@ -281,6 +281,7 @@ public class ResourcePackListener implements Listener {
         Player player = pqe.getPlayer();
         plugin.removeFromWaiting(player);
         sentAccept.remove(player.getUniqueId());
+        plugin.temporaryExemptedPlayers.remove(player.getUniqueId());
     }
 
     private void ensureMainThread(Runnable runnable) {

--- a/velocity/src/main/java/com/convallyria/forcepack/velocity/ForcePackVelocity.java
+++ b/velocity/src/main/java/com/convallyria/forcepack/velocity/ForcePackVelocity.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -87,6 +88,7 @@ public class ForcePackVelocity implements ForcePackAPI {
     public Optional<ForcePackWebServer> getWebServer() {
         return Optional.ofNullable(webServer);
     }
+    public final Set<UUID> temporaryExemptedPlayers = new HashSet<>();
 
     @Inject
     public ForcePackVelocity(PluginContainer container, ProxyServer server, Logger logger, @DataDirectory Path dataDirectory, Metrics.Factory metricsFactory, CommandManager commandManager) {
@@ -548,6 +550,11 @@ public class ForcePackVelocity implements ForcePackAPI {
     @Override
     public PlatformScheduler<?> getScheduler() {
         return scheduler;
+    }
+
+    @Override
+    public boolean exemptNextResourcePackSend(UUID uuid) {
+        return temporaryExemptedPlayers.add(uuid);
     }
 
     public Optional<Set<ResourcePack>> getPacksByServerAndVersion(final String server, final ProtocolVersion version) {

--- a/velocity/src/main/java/com/convallyria/forcepack/velocity/listener/ResourcePackListener.java
+++ b/velocity/src/main/java/com/convallyria/forcepack/velocity/listener/ResourcePackListener.java
@@ -75,7 +75,7 @@ public class ResourcePackListener {
         }
 
         if (plugin.temporaryExemptedPlayers.remove(player.getUniqueId())) {
-            plugin.log("Ignoring player " + player.getUsername() + " as they has a one-off exemption.");
+            plugin.log("Ignoring player " + player.getUsername() + " as they have a one-off exemption.");
             return;
         }
 
@@ -178,5 +178,10 @@ public class ResourcePackListener {
         if (!canBypass && !geyser) {
             plugin.getPackHandler().setPack(player, currentServer.get());
         }
+    }
+
+    @Subscribe(order = PostOrder.LATE)
+    public void onQuit(DisconnectEvent event) {
+        plugin.temporaryExemptedPlayers.remove(event.getPlayer().getUniqueId());
     }
 }

--- a/velocity/src/main/java/com/convallyria/forcepack/velocity/listener/ResourcePackListener.java
+++ b/velocity/src/main/java/com/convallyria/forcepack/velocity/listener/ResourcePackListener.java
@@ -74,6 +74,11 @@ public class ResourcePackListener {
             return;
         }
 
+        if (plugin.temporaryExemptedPlayers.remove(player.getUniqueId())) {
+            plugin.log("Ignoring player " + player.getUsername() + " as they has a one-off exemption.");
+            return;
+        }
+
         final VelocityConfig root;
         if (packByServer.getServer().contains(ForcePackVelocity.GLOBAL_SERVER_NAME)) {
             root = plugin.getConfig().getConfig("global-pack");


### PR DESCRIPTION
Some of this was reposted in the Discord, but the aim of this PR is to be able to exempt players from their next resource pack update.

(Unless there's an actual way to do this) The reason for this is to handle players transferring back and forth between Velocity proxies (via transfer packets), but not wanting to forcibly reload a player's pack(s). 

At the moment I'm using LuckPerms Velocity to grant players a tempperm of `forcepack.bypass` but that is quite ugly and noisy (log-wise). I'd rather just be able to access the ForcePack API to call this new method.

This is a simple implementation, open to expansion on this but would love to have it.