### PR TITLE
Fix pack exemption on velocity

### DIFF
--- a/velocity/src/main/java/com/convallyria/forcepack/velocity/listener/ResourcePackListener.java
+++ b/velocity/src/main/java/com/convallyria/forcepack/velocity/listener/ResourcePackListener.java
@@ -74,11 +74,6 @@ public class ResourcePackListener {
             return;
         }
 
-        if (plugin.temporaryExemptedPlayers.remove(player.getUniqueId())) {
-            plugin.log("Ignoring player " + player.getUsername() + " as they have a one-off exemption.");
-            return;
-        }
-
         final VelocityConfig root;
         if (packByServer.getServer().contains(ForcePackVelocity.GLOBAL_SERVER_NAME)) {
             root = plugin.getConfig().getConfig("global-pack");
@@ -175,6 +170,12 @@ public class ResourcePackListener {
         final Player player = event.getPlayer();
         final Optional<ServerConnection> currentServer = player.getCurrentServer();
         if (currentServer.isEmpty()) return;
+
+        if (plugin.temporaryExemptedPlayers.remove(player.getUniqueId())) {
+            plugin.log("Ignoring player " + player.getUsername() + " as they have a one-off exemption.");
+            return;
+        }
+
         plugin.getPackHandler().setPack(player, currentServer.get());
     }
 


### PR DESCRIPTION
Not sure if I just missed this in my last PR but exemption didn't work on Velocity at least, the old exemption check was too late, the pack had already been sent to the user.